### PR TITLE
fix: remove unexpected generation of empty table in db

### DIFF
--- a/app/models/voting.js
+++ b/app/models/voting.js
@@ -52,6 +52,8 @@ export const votingSchema = new Schema(
   },
   {
     _id: false,
+    autoCreate: false,
+    autoIndex: false,
   }
 );
 


### PR DESCRIPTION
Remove the files that auto-generate an empty table "votings" in database. 